### PR TITLE
Add srcUrl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ plugins: [
 
       // number (default to 1000); time to wait after scroll or route change
       // To be used when `delayLoad` is set to `true`
-      delayLoadTime: 1000
+      delayLoadTime: 1000,
 
       // Whether to completely skip calling `analytics.load()`.
       // ADVANCED FEATURE: only use if you are calling `analytics.load()` manually
@@ -93,13 +93,17 @@ plugins: [
       // that will call it for you.
       // Useful for only loading the tracking script once a user has opted in to being tracked, for example.
       // *Another use case is if you want to add callbacks to the methods at load time.
-      manualLoad: false
+      manualLoad: false,
 
       // string ('async' or 'defer'); whether to load the RudderStack SDK async or defer. Anything else
       // will load normally.
       // 'async' will load the SDK as <script async></script>
       // 'defer' will load the SDK as <script defer></script>
-      loadType: 'default'
+      loadType: 'default',
+
+      // jsLocation can be used to override the location of the javascript library. This is useful
+      // if you provide your own js or a proxy.
+      srcUrl: 'https://cdn.rudderlabs.com/v1/rudder-analytics.min.js'
     }
   }
 ];

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -17,7 +17,8 @@ exports.onRenderBody = function (_ref, pluginOptions) {
       delayLoad = pluginOptions.delayLoad,
       delayLoadTime = pluginOptions.delayLoadTime,
       manualLoad = pluginOptions.manualLoad,
-      loadType = pluginOptions.loadType;
+      loadType = pluginOptions.loadType,
+      srcUrl = pluginOptions.srcUrl;
 
   if (!prodKey || prodKey.length < 10) console.error("Your Rudderstack prodKey must be at least 10 char in length.");
 
@@ -47,17 +48,17 @@ exports.onRenderBody = function (_ref, pluginOptions) {
     if (loadType == 'async') {
       tag = _react2.default.createElement("script", { async: true,
         key: "rudderstack-cdn",
-        src: "https://cdn.rudderlabs.com/v1/rudder-analytics.min.js"
+        src: srcUrl || 'https://cdn.rudderlabs.com/v1/rudder-analytics.min.js'
       });
     } else if (loadType == 'defer') {
       tag = _react2.default.createElement("script", { defer: true,
         key: "rudderstack-cdn",
-        src: "https://cdn.rudderlabs.com/v1/rudder-analytics.min.js"
+        src: srcUrl || 'https://cdn.rudderlabs.com/v1/rudder-analytics.min.js'
       });
     } else {
       tag = _react2.default.createElement("script", {
         key: "rudderstack-cdn",
-        src: "https://cdn.rudderlabs.com/v1/rudder-analytics.min.js"
+        src: srcUrl || 'https://cdn.rudderlabs.com/v1/rudder-analytics.min.js'
       });
     }
 

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -10,7 +10,8 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     delayLoad,
     delayLoadTime,
     manualLoad,
-    loadType
+    loadType,
+    srcUrl
   } = pluginOptions;
 
   // ensures Rudderstack production write key is present
@@ -93,17 +94,17 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     if (loadType == 'async') {
       tag = <script async
         key="rudderstack-cdn"
-        src="https://cdn.rudderlabs.com/v1/rudder-analytics.min.js"
+        src={srcUrl || 'https://cdn.rudderlabs.com/v1/rudder-analytics.min.js'}
       ></script>
     } else if (loadType == 'defer') {
       tag = <script defer
         key="rudderstack-cdn"
-        src="https://cdn.rudderlabs.com/v1/rudder-analytics.min.js"
+        src={srcUrl || 'https://cdn.rudderlabs.com/v1/rudder-analytics.min.js'}
       ></script>
     } else {
       tag = <script
         key="rudderstack-cdn"
-        src="https://cdn.rudderlabs.com/v1/rudder-analytics.min.js"
+        src={srcUrl || 'https://cdn.rudderlabs.com/v1/rudder-analytics.min.js'}
     ></script>
     }
 


### PR DESCRIPTION
This PR adds a `srcUrl` option to the plugin options that updates the location of the rudderstack javascript library in the `<script src=...`. This is mainly to add a proxy between the location and the rudderstack source so ad blockers won't block fetching the javascript sdk. Together with the `controlPlaneUrl` and the `dataPlaneUrl` you can now hide rudderstack completely behind proxies.

I updated the docs so it is explained what it does and built the code so it has the new code.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code (already working in our codebase)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code **(<-- there aren't any)**
- [x] I have made corresponding changes to the documentation
