### PR TITLE
Feature: Added option to configure SDK URL

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -24,9 +24,10 @@ exports.onRenderBody = function (_ref, pluginOptions) {
     manualLoad = pluginOptions.manualLoad,
     loadType = pluginOptions.loadType,
     useNewSDK = pluginOptions.useNewSDK,
-    loadOptions = pluginOptions.loadOptions;
+    loadOptions = pluginOptions.loadOptions,
+    sdkURL = pluginOptions.sdkURL;
 
-  var sdkSrc = "https://cdn.rudderlabs.com/v1/rudder-analytics.min.js";
+  var sdkSrc = sdkURL || "https://cdn.rudderlabs.com/v1/rudder-analytics.min.js";
   if (useNewSDK) {
     sdkSrc = "https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js";
   }

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -27,8 +27,9 @@ exports.onRenderBody = function (_ref, pluginOptions) {
     loadOptions = pluginOptions.loadOptions,
     sdkURL = pluginOptions.sdkURL;
 
-  var sdkSrc = sdkURL || "https://cdn.rudderlabs.com/v1/rudder-analytics.min.js";
-  if (useNewSDK) {
+  var sdkSrc = "https://cdn.rudderlabs.com/v1/rudder-analytics.min.js";
+  if (sdkURL) sdkSrc = sdkURL;
+  else if (useNewSDK) {
     sdkSrc = "https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js";
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatsby-plugin-rudderstack",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gatsby-plugin-rudderstack",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "babel-cli": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-rudderstack",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Event tracking with RudderStack in your Gatsby frontend.",
   "main": "gatsby-ssr.js",
   "scripts": {

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -15,8 +15,9 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     sdkURL,
   } = pluginOptions;
 
-  var sdkSrc = sdkURL || "https://cdn.rudderlabs.com/v1/rudder-analytics.min.js";
-  if (useNewSDK) {
+  var sdkSrc = "https://cdn.rudderlabs.com/v1/rudder-analytics.min.js";
+  if (sdkURL) sdkSrc = sdkURL;
+  else if (useNewSDK) {
     sdkSrc = "https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js";
   }
 

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -12,9 +12,10 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     manualLoad,
     loadType,
     useNewSDK,
+    sdkURL,
   } = pluginOptions;
 
-  var sdkSrc = "https://cdn.rudderlabs.com/v1/rudder-analytics.min.js";
+  var sdkSrc = sdkURL || "https://cdn.rudderlabs.com/v1/rudder-analytics.min.js";
   if (useNewSDK) {
     sdkSrc = "https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js";
   }


### PR DESCRIPTION
# Description
Added a new option `sdkURL` to specify the URL of the RudderStack JavaScript SDK. If this option is not configured, the default URL will be used.
Moreover, this option takes precedence over `useNewSDK`.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
